### PR TITLE
disable rubygem mfa

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,6 @@ Style/StringLiteralsInInterpolation:
 
 Layout/LineLength:
   Max: 120
+
+Gemspec/RequireMFA:
+  Enabled: false

--- a/foreman_envsync.gemspec
+++ b/foreman_envsync.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |spec|
 
   # For more information and examples about making a new gem, checkout our
   # guide at: https://bundler.io/guides/creating_gem.html
-  spec.metadata["rubygems_mfa_required"] = "true"
+  spec.metadata["rubygems_mfa_required"] = "false"
 end


### PR DESCRIPTION
The mfa flag means that *all* new uploads of the gem require an OTP...
which effectively means that new releases can not be pushed from gha.