### PR TITLE
fix `sort': comparison of Hash with Hash failed error 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+require:
+  - rubocop-rake
+  - rubocop-rspec
+
 AllCops:
   TargetRubyVersion: 2.5
   NewCops: enable

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 3.0
   NewCops: enable
 
 Style/StringLiterals:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,3 +19,20 @@ Layout/LineLength:
 
 Gemspec/RequireMFA:
   Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+Metrics/BlockLength:
+  Enabled: false
+Metrics/ClassLength:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/MethodLength:
+  Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
+Metrics/ParameterLists:
+  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false

--- a/exe/foreman_envsync
+++ b/exe/foreman_envsync
@@ -31,8 +31,15 @@ def verbose_list(msg, items)
   return unless @options[:verbose] && !items.nil?
 
   printf(msg, items.count)
+  return if items.empty?
+
   puts
-  puts "#{YAML.dump(items.sort)}\n" unless items.empty?
+  # do not attempt to sorry Array of Hashes
+  if items.is_a?(Array) && items.first.is_a?(Hash)
+    puts "#{YAML.dump(items)}\n"
+  else
+    puts "#{YAML.dump(items.sort)}\n"
+  end
 end
 
 def cert_file(file)

--- a/exe/foreman_envsync
+++ b/exe/foreman_envsync
@@ -8,22 +8,24 @@ require "rest-client"
 require "socket"
 require "yaml"
 
-@options = {}
-option_parser = OptionParser.new do |opts|
-  opts.banner = "Usage: foreman_envsync [options]"
-  opts.separator ""
-  opts.separator "Specifc options:"
+def parse_options
+  @options = {}
+  option_parser = OptionParser.new do |opts|
+    opts.banner = "Usage: foreman_envsync [options]"
+    opts.separator ""
+    opts.separator "Specifc options:"
 
-  opts.on("-v", "--verbose", "Enable verbose output") do |o|
-    @options[:verbose] = [o]
-  end
+    opts.on("-v", "--verbose", "Enable verbose output") do |o|
+      @options[:verbose] = [o]
+    end
 
-  opts.on_tail("-h", "--help", "Show this message") do
-    puts opts
-    exit
+    opts.on_tail("-h", "--help", "Show this message") do
+      puts opts
+      exit
+    end
   end
+  option_parser.parse!
 end
-option_parser.parse!
 
 def verbose_list(msg, items)
   return unless @options[:verbose] && !items.nil?
@@ -126,53 +128,59 @@ def puppetserver_env_list
   JSON.parse(res)["environments"].keys
 end
 
-#
-# Fetch list of puppet environments from puppetserver API.
-#
-ps_envs = puppetserver_env_list
-verbose_list "found %d puppetserver environment(s).", ps_envs
+def main
+  parse_options
 
-#
-# Fetch list of puppet environments from foreman. The hammer cli is used to
-# avoid having to manage credentials.  In theory, foreman supports auth using
-# x509 similar to puppetserver but this failed when tested using both `curl` and
-# configuring hammer to use x509.
-#
-f_envs = foreman_env_list
-verbose_list "found %d foreman environment(s).", f_envs
+  #
+  # Fetch list of puppet environments from puppetserver API.
+  #
+  ps_envs = puppetserver_env_list
+  verbose_list "found %d puppetserver environment(s).", ps_envs
 
-#
-# Does foreman have any puppet envs puppetserver is unaware of?
-#
-extra_envs = f_envs - ps_envs
-verbose_list "found %d foreman environment(s) unknown to puppetserver.", extra_envs
+  #
+  # Fetch list of puppet environments from foreman. The hammer cli is used to
+  # avoid having to manage credentials.  In theory, foreman supports auth using
+  # x509 similar to puppetserver but this failed when tested using both `curl` and
+  # configuring hammer to use x509.
+  #
+  f_envs = foreman_env_list
+  verbose_list "found %d foreman environment(s).", f_envs
 
-#
-# Remove any foreman envs unknown to puppetserver
-#
-report = extra_envs.collect { |x| foreman_env_delete(x) } unless extra_envs.empty?
-verbose_list "deleted %d foreman environment(s).", report.nil? ? nil : report.compact
+  #
+  # Does foreman have any puppet envs puppetserver is unaware of?
+  #
+  extra_envs = f_envs - ps_envs
+  verbose_list "found %d foreman environment(s) unknown to puppetserver.", extra_envs
 
-# update foreman envs if anything was deleted
-f_envs = foreman_env_list unless report.nil?
+  #
+  # Remove any foreman envs unknown to puppetserver
+  #
+  report = extra_envs.collect { |x| foreman_env_delete(x) } unless extra_envs.empty?
+  verbose_list "deleted %d foreman environment(s).", report.nil? ? nil : report.compact
 
-#
-# Does puppetserver have any envs foreman is unaware of?
-#
-new_envs = ps_envs - f_envs
-verbose_list "found %d puppetserver environment(s) unknown to foreman.", new_envs
+  # update foreman envs if anything was deleted
+  f_envs = foreman_env_list unless report.nil?
 
-# if not, exit
-exit 0 if new_envs.empty?
+  #
+  # Does puppetserver have any envs foreman is unaware of?
+  #
+  new_envs = ps_envs - f_envs
+  verbose_list "found %d puppetserver environment(s) unknown to foreman.", new_envs
 
-#
-# Create new foreman env(s) with all existing locations and organizations
-#
-location_ids = foreman_location_ids
-verbose_list "found %d foreman location(s).", location_ids
+  # if not, exit
+  exit 0 if new_envs.empty?
 
-org_ids = foreman_org_ids
-verbose_list "found %d foreman organization(s).", org_ids
+  #
+  # Create new foreman env(s) with all existing locations and organizations
+  #
+  location_ids = foreman_location_ids
+  verbose_list "found %d foreman location(s).", location_ids
 
-report = new_envs.collect { |x| foreman_env_create(x, location_ids, org_ids) }
-verbose_list "created %d foreman environment(s).", report
+  org_ids = foreman_org_ids
+  verbose_list "found %d foreman organization(s).", org_ids
+
+  report = new_envs.collect { |x| foreman_env_create(x, location_ids, org_ids) }
+  verbose_list "created %d foreman environment(s).", report
+end
+
+main if File.basename($PROGRAM_NAME) == File.basename(__FILE__)

--- a/foreman_envsync.gemspec
+++ b/foreman_envsync.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "Sync pupperserver envs with foreman"
   spec.homepage      = "https://github.com/lsst-it/foreman_envsync"
   spec.license       = "MIT"
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/lsst-it/foreman_envsync"

--- a/spec/foreman_envsync_spec.rb
+++ b/spec/foreman_envsync_spec.rb
@@ -2,6 +2,6 @@
 
 RSpec.describe ForemanEnvsync do
   it "has a version number" do
-    expect(ForemanEnvsync::VERSION).not_to be nil
+    expect(ForemanEnvsync::VERSION).not_to be_nil
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,13 @@
 # frozen_string_literal: true
 
+def root_path
+  File.expand_path(File.join(__FILE__, "..", ".."))
+end
+
 require "foreman_envsync"
+load "#{root_path}/exe/foreman_envsync"
 
 RSpec.configure do |config|
-  # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
-
-  # Disable RSpec exposing methods globally on `Module` and `main`
-  config.disable_monkey_patching!
-
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end

--- a/spec/unit/foreman_envsync_verbose_list_spec.rb
+++ b/spec/unit/foreman_envsync_verbose_list_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ForemanEnvsync do
+  describe "#verbose_list" do
+    before { @options = { verbose: true } }
+
+    context "with array of hash" do
+      let(:aofh) { [{ a: 1 }, { b: 2 }] }
+      let(:foo_output) do
+        <<~FOO
+          foo
+          ---
+          - :a: 1
+          - :b: 2
+
+        FOO
+      end
+
+      it { expect { verbose_list("foo", aofh) }.to output(foo_output).to_stdout }
+    end
+  end
+end

--- a/spec/unit/foreman_envsync_version_spec.rb
+++ b/spec/unit/foreman_envsync_version_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-RSpec.describe ForemanEnvsync do
+require "spec_helper"
+
+describe ForemanEnvsync do
   it "has a version number" do
     expect(ForemanEnvsync::VERSION).not_to be_nil
   end


### PR DESCRIPTION
If foreman_envsync was trying to create or delete multiple environments this stack trace would be reported:

```
/usr/local/bundle/gems/foreman_envsync-1.3.0/exe/foreman_envsync:33:in `sort': comparison of Hash with Hash failed (ArgumentError)
--
from /usr/local/bundle/gems/foreman_envsync-1.3.0/exe/foreman_envsync:33:in `verbose_list'
from /usr/local/bundle/gems/foreman_envsync-1.3.0/exe/foreman_envsync:154:in `<top (required)>'
from /usr/local/bundle/bin/foreman_envsync:25:in `load'
from /usr/local/bundle/bin/foreman_envsync:25:in `<main>'
```

