### PR TITLE
push to rubygems after build & push of OCI images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,12 +41,6 @@ jobs:
       - name: Build gem
         run: gem build *.gemspec
 
-      - name: Publish gem to rubygems.org
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: gem push *.gem
-        env:
-          GEM_HOST_API_KEY: '${{ secrets.RUBYGEMS_AUTH_TOKEN }}'
-
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -82,3 +76,9 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Publish gem to rubygems.org
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: gem push *.gem
+        env:
+          GEM_HOST_API_KEY: '${{ secrets.RUBYGEMS_AUTH_TOKEN }}'


### PR DESCRIPTION
For the v1.5.0 release, the push to rubygems returned an API error even though the push was successful. As rubygems does not allow repushing the same version, it was not possible to rerun the workflow to build + push the OCI images.  By reordering the sequence of steps so the push to rubygems in the last step, this will hopefully allow for a complete release process even though the gha job will have a failure status.